### PR TITLE
Add empty basemap option

### DIFF
--- a/src/lib/__tests__/basemaps.spec.ts
+++ b/src/lib/__tests__/basemaps.spec.ts
@@ -12,6 +12,12 @@ describe('basemap configurations', () => {
     }
   });
 
+  it('includes an empty white basemap', () => {
+    const empty = basemapConfigs.empty;
+    expect(empty.style.layers[0].type).toBe('background');
+    expect(empty.style.layers[0].paint?.['background-color']).toBe('#ffffff');
+  });
+
   it('includes a demo WMS layer', () => {
     const wms = basemapConfigs.wms;
     const source = wms.style.sources.states;

--- a/src/lib/basemaps.ts
+++ b/src/lib/basemaps.ts
@@ -1,6 +1,6 @@
 import type { StyleSpecification } from 'maplibre-gl';
 
-export type BasemapId = 'osm' | 'wms' | 'swisstopo';
+export type BasemapId = 'empty' | 'osm' | 'wms' | 'swisstopo';
 
 export interface BasemapConfig {
   id: BasemapId;
@@ -27,6 +27,21 @@ const osmStyle: StyleSpecification = {
       source: 'osm',
       minzoom: 0,
       maxzoom: 19
+    }
+  ]
+};
+
+const emptyStyle: StyleSpecification = {
+  version: 8,
+  name: 'Empty',
+  sources: {},
+  layers: [
+    {
+      id: 'empty-background',
+      type: 'background',
+      paint: {
+        'background-color': '#ffffff'
+      }
     }
   ]
 };
@@ -59,6 +74,12 @@ const swisstopoStyle =
   'https://vectortiles.geo.admin.ch/styles/ch.swisstopo.basemap.vt/style.json?key=xmETqTBaiAH9bbZXXiFm';
 
 export const basemapConfigs: Record<BasemapId, BasemapConfig> = {
+  empty: {
+    id: 'empty',
+    label: 'Empty',
+    description: 'A blank white background suitable for focusing on overlay data.',
+    style: emptyStyle
+  },
   osm: {
     id: 'osm',
     label: 'OpenStreetMap',


### PR DESCRIPTION
## Summary
- add a white "Empty" basemap configuration that renders only a background layer
- expose the new option through the basemap configuration registry and cover it with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de4d1041708328b86ec8281b390713