### PR TITLE
Add disk-backed WMS proxy cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ npm run test
 
 To display your PMTiles data, update the `pmtilesLayers` array in `src/routes/+page.svelte` with the sources and layers you want to show. Each entry supports vector or raster sources and can be styled with MapLibre paint and layout properties.
 
+## WMS proxy cache
+
+Requests to the "Hintergrundkarte schwarz/weiss" layer are routed through `/api/wms`, which caches PNG responses on disk to reduce load on the upstream service. You can control the cache with the following environment variables:
+
+- `WMS_CACHE_DIR` – directory used to store cached tiles (defaults to `.wms-cache` in the project root).
+- `WMS_CACHE_MAX_BYTES` – maximum cache size in bytes before the oldest entries are pruned (defaults to 10 GB).
+- `WMS_CACHE_MAX_AGE_MS` – time-to-live for cached PNGs in milliseconds (defaults to one day).
+- `WMS_PROXY_BASE_URL` – upstream WMS base URL (defaults to `https://geo.so.ch/api/wms`).
+
 ## Production build
 
 Create a production build with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/jest-dom": "^6.9.0",
         "@testing-library/svelte": "^5.2.8",
         "@types/jsdom": "^27.0.0",
+        "@types/node": "^22.9.0",
         "jsdom": "^27.0.0",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
@@ -1407,13 +1408,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.1.tgz",
-      "integrity": "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==",
+      "version": "22.18.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
+      "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.13.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/supercluster": {
@@ -2900,9 +2901,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@testing-library/jest-dom": "^6.9.0",
     "@testing-library/svelte": "^5.2.8",
     "@types/jsdom": "^27.0.0",
+    "@types/node": "^22.9.0",
     "jsdom": "^27.0.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",

--- a/src/lib/basemaps.ts
+++ b/src/lib/basemaps.ts
@@ -53,7 +53,7 @@ const hintergrundkarteStyle: StyleSpecification = {
     hintergrundkarte: {
       type: 'raster',
       tiles: [
-        'https://geo.so.ch/api/wms?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&FORMAT=image/png&TRANSPARENT=true&LAYERS=ch.so.agi.hintergrundkarte_sw&STYLES=&CRS=EPSG:3857&WIDTH=256&HEIGHT=256&DPI=96&OPACITIES=255&BBOX={bbox-epsg-3857}'
+        '/api/wms?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&FORMAT=image/png&TRANSPARENT=true&LAYERS=ch.so.agi.hintergrundkarte_sw&STYLES=&CRS=EPSG:3857&WIDTH=256&HEIGHT=256&DPI=96&OPACITIES=255&BBOX={bbox-epsg-3857}'
       ],
       tileSize: 256,
       attribution: '© Amt für Geoinformation Kanton Solothurn'

--- a/src/lib/server/wmsCache.ts
+++ b/src/lib/server/wmsCache.ts
@@ -1,0 +1,156 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+interface CacheEntryMeta {
+  key: string;
+  hash: string;
+  createdAt: number;
+  lastAccessed: number;
+  size: number;
+  contentType: string;
+}
+
+export interface CacheOptions {
+  directory: string;
+  maxBytes: number;
+  maxAgeMs: number;
+}
+
+export interface CacheHit {
+  buffer: Buffer;
+  contentType: string;
+}
+
+export class WMSCache {
+  private ready = false;
+
+  constructor(private readonly options: CacheOptions) {}
+
+  private async ensureReady() {
+    if (this.ready) return;
+    await fs.mkdir(this.options.directory, { recursive: true });
+    this.ready = true;
+  }
+
+  private static hashKey(key: string): string {
+    return crypto.createHash('sha256').update(key).digest('hex');
+  }
+
+  private entryPaths(hash: string) {
+    const baseName = path.join(this.options.directory, hash);
+    return {
+      dataPath: `${baseName}.bin`,
+      metaPath: `${baseName}.json`
+    };
+  }
+
+  private async readMeta(metaPath: string): Promise<CacheEntryMeta | null> {
+    try {
+      const raw = await fs.readFile(metaPath, 'utf-8');
+      const meta = JSON.parse(raw) as CacheEntryMeta;
+      if (!meta.hash || !meta.createdAt || !meta.size) return null;
+      return meta;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  private async writeMeta(metaPath: string, meta: CacheEntryMeta) {
+    await fs.writeFile(metaPath, JSON.stringify(meta));
+  }
+
+  private async deleteEntry(hash: string) {
+    const { dataPath, metaPath } = this.entryPaths(hash);
+    await fs.rm(dataPath, { force: true });
+    await fs.rm(metaPath, { force: true });
+  }
+
+  private async allMetas(): Promise<CacheEntryMeta[]> {
+    await this.ensureReady();
+    const files = await fs.readdir(this.options.directory);
+    const metas: CacheEntryMeta[] = [];
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      const meta = await this.readMeta(path.join(this.options.directory, file));
+      if (meta) {
+        metas.push(meta);
+      }
+    }
+    return metas;
+  }
+
+  private async prune() {
+    const now = Date.now();
+    const metas = await this.allMetas();
+    const freshMetas: CacheEntryMeta[] = [];
+
+    for (const meta of metas) {
+      const isExpired = now - meta.createdAt > this.options.maxAgeMs;
+      if (isExpired) {
+        await this.deleteEntry(meta.hash);
+      } else {
+        freshMetas.push(meta);
+      }
+    }
+
+    let totalSize = freshMetas.reduce((sum, entry) => sum + entry.size, 0);
+
+    if (totalSize <= this.options.maxBytes) {
+      return;
+    }
+
+    freshMetas.sort((a, b) => a.createdAt - b.createdAt);
+
+    while (totalSize > this.options.maxBytes && freshMetas.length > 0) {
+      const oldest = freshMetas.shift();
+      if (!oldest) break;
+      await this.deleteEntry(oldest.hash);
+      totalSize -= oldest.size;
+    }
+  }
+
+  async get(key: string): Promise<CacheHit | null> {
+    await this.ensureReady();
+    const hash = WMSCache.hashKey(key);
+    const { dataPath, metaPath } = this.entryPaths(hash);
+    const meta = await this.readMeta(metaPath);
+    if (!meta) return null;
+
+    const isExpired = Date.now() - meta.createdAt > this.options.maxAgeMs;
+    if (isExpired) {
+      await this.deleteEntry(hash);
+      return null;
+    }
+
+    try {
+      const buffer = await fs.readFile(dataPath);
+      meta.lastAccessed = Date.now();
+      await this.writeMeta(metaPath, meta);
+      return { buffer, contentType: meta.contentType };
+    } catch (error) {
+      await this.deleteEntry(hash);
+      return null;
+    }
+  }
+
+  async set(key: string, buffer: Buffer, contentType: string) {
+    await this.ensureReady();
+    const hash = WMSCache.hashKey(key);
+    const { dataPath, metaPath } = this.entryPaths(hash);
+    const now = Date.now();
+    const meta: CacheEntryMeta = {
+      key,
+      hash,
+      createdAt: now,
+      lastAccessed: now,
+      size: buffer.byteLength,
+      contentType
+    };
+
+    await fs.writeFile(dataPath, buffer);
+    await this.writeMeta(metaPath, meta);
+
+    await this.prune();
+  }
+}

--- a/src/lib/server/wmsProxyConfig.ts
+++ b/src/lib/server/wmsProxyConfig.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { env } from '$env/dynamic/private';
+
+const DEFAULT_DIRECTORY = path.resolve(process.cwd(), '.wms-cache');
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024 * 1024; // 10 GB
+const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 1 day
+const DEFAULT_WMS_BASE_URL = 'https://geo.so.ch/api/wms';
+
+const parseInteger = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+export const wmsCacheDirectory = env.WMS_CACHE_DIR
+  ? path.resolve(env.WMS_CACHE_DIR)
+  : DEFAULT_DIRECTORY;
+
+export const wmsCacheMaxBytes = parseInteger(env.WMS_CACHE_MAX_BYTES, DEFAULT_MAX_BYTES);
+
+export const wmsCacheMaxAgeMs = parseInteger(env.WMS_CACHE_MAX_AGE_MS, DEFAULT_MAX_AGE_MS);
+
+export const wmsProxyBaseUrl = env.WMS_PROXY_BASE_URL ?? DEFAULT_WMS_BASE_URL;

--- a/src/routes/api/wms/+server.ts
+++ b/src/routes/api/wms/+server.ts
@@ -1,0 +1,70 @@
+import type { RequestHandler } from './$types';
+import { error } from '@sveltejs/kit';
+import { WMSCache } from '$lib/server/wmsCache';
+import {
+  wmsCacheDirectory,
+  wmsCacheMaxAgeMs,
+  wmsCacheMaxBytes,
+  wmsProxyBaseUrl
+} from '$lib/server/wmsProxyConfig';
+
+const cache = new WMSCache({
+  directory: wmsCacheDirectory,
+  maxAgeMs: wmsCacheMaxAgeMs,
+  maxBytes: wmsCacheMaxBytes
+});
+
+const isPngResponse = (contentType: string | null) =>
+  !!contentType && contentType.toLowerCase().includes('image/png');
+
+export const GET: RequestHandler = async ({ url, fetch, setHeaders }) => {
+  if (!url.searchParams.size) {
+    throw error(400, 'Missing WMS query parameters.');
+  }
+
+  const upstreamUrl = `${wmsProxyBaseUrl}?${url.searchParams.toString()}`;
+
+  const cached = await cache.get(upstreamUrl);
+  if (cached) {
+    setHeaders({
+      'Content-Type': cached.contentType,
+      'Cache-Control': 'public, max-age=0, must-revalidate'
+    });
+
+    const body = new Uint8Array(cached.buffer);
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'Content-Type': cached.contentType
+      }
+    });
+  }
+
+  const response = await fetch(upstreamUrl);
+
+  if (!response.ok) {
+    throw error(response.status, `Upstream WMS request failed with status ${response.status}.`);
+  }
+
+  const contentType = response.headers.get('content-type');
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  if (isPngResponse(contentType)) {
+    await cache.set(upstreamUrl, buffer, contentType ?? 'image/png');
+  }
+
+  const headers = new Headers();
+  if (contentType) {
+    headers.set('Content-Type', contentType);
+    setHeaders({ 'Content-Type': contentType });
+  }
+
+  headers.set('Cache-Control', 'public, max-age=0, must-revalidate');
+  setHeaders({ 'Cache-Control': 'public, max-age=0, must-revalidate' });
+
+  const body = new Uint8Array(buffer);
+
+  return new Response(body, { status: response.status, headers });
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,23 @@
 {
-	"extends": "./.svelte-kit/tsconfig.json",
-"compilerOptions": {
-"allowJs": true,
-"checkJs": true,
-"esModuleInterop": true,
-"forceConsistentCasingInFileNames": true,
-"resolveJsonModule": true,
-"skipLibCheck": true,
-"sourceMap": true,
-"strict": true,
-"moduleResolution": "bundler",
-"types": [
-"vitest/globals"
-]
-}
-	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
-	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
-	//
-	// To make changes to top-level options such as include and exclude, we recommend extending
-	// the generated config; see https://svelte.dev/docs/kit/configuration#typescript
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler",
+    "types": [
+      "vitest/globals",
+      "node"
+    ]
+  }
+  // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
+  // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
+  //
+  // To make changes to top-level options such as include and exclude, we recommend extending
+  // the generated config; see https://svelte.dev/docs/kit/configuration#typescript
 }


### PR DESCRIPTION
## Summary
- add a configurable disk-backed cache and `/api/wms` proxy that reuses cached PNG tiles
- update the Hintergrundkarte basemap to hit the local proxy and document the cache environment variables
- tighten basemap tests and tooling to handle inline styles and Node typings

## Testing
- npm run check
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dec7d7c4e0832880dfd054d2a83b72