### PR TITLE
Add swisstopo imagery basemap option

### DIFF
--- a/src/lib/__tests__/basemaps.spec.ts
+++ b/src/lib/__tests__/basemaps.spec.ts
@@ -57,4 +57,16 @@ describe('basemap configurations', () => {
       throw new Error('swisstopo style should be provided as a hosted style URL');
     }
   });
+
+  it('includes the swisstopo imagery basemap style URL', () => {
+    const swisstopoImagery = basemapConfigs.swisstopoImagery;
+    if (typeof swisstopoImagery.style === 'string') {
+      expect(swisstopoImagery.style).toContain(
+        'vectortiles.geo.admin.ch/styles/ch.swisstopo.imagerybasemap'
+      );
+      expect(swisstopoImagery.style).toContain('style.json');
+    } else {
+      throw new Error('swisstopo imagery style should be provided as a hosted style URL');
+    }
+  });
 });

--- a/src/lib/basemaps.ts
+++ b/src/lib/basemaps.ts
@@ -1,6 +1,11 @@
 import type { StyleSpecification } from 'maplibre-gl';
 
-export type BasemapId = 'empty' | 'osm' | 'hintergrundkarte' | 'swisstopo';
+export type BasemapId =
+  | 'empty'
+  | 'osm'
+  | 'hintergrundkarte'
+  | 'swisstopo'
+  | 'swisstopoImagery';
 
 export interface BasemapConfig {
   id: BasemapId;
@@ -73,12 +78,21 @@ const hintergrundkarteStyle: StyleSpecification = {
 const swisstopoStyle =
   'https://vectortiles.geo.admin.ch/styles/ch.swisstopo.basemap.vt/style.json?key=xmETqTBaiAH9bbZXXiFm';
 
+const swisstopoImageryStyle =
+  'https://vectortiles.geo.admin.ch/styles/ch.swisstopo.imagerybasemap.vt/style.json?key=xmETqTBaiAH9bbZXXiFm';
+
 export const basemapConfigs: Record<BasemapId, BasemapConfig> = {
   swisstopo: {
     id: 'swisstopo',
     label: 'swisstopo Vector Basemap',
     description: 'Official Swiss vector basemap provided by swisstopo.',
     style: swisstopoStyle
+  },
+  swisstopoImagery: {
+    id: 'swisstopoImagery',
+    label: 'swisstopo Imagery Basemap',
+    description: 'High-resolution imagery basemap provided by swisstopo.',
+    style: swisstopoImageryStyle
   },
   hintergrundkarte: {
     id: 'hintergrundkarte',
@@ -103,6 +117,7 @@ export const basemapConfigs: Record<BasemapId, BasemapConfig> = {
 export const basemapOptions: BasemapConfig[] = [
   basemapConfigs.swisstopo,
   basemapConfigs.hintergrundkarte,
+  basemapConfigs.swisstopoImagery,
   basemapConfigs.osm,
   basemapConfigs.empty
 ];


### PR DESCRIPTION
## Summary
- add the swisstopo imagery basemap configuration and expose it after the Hintergrundkarte option
- extend basemap tests to cover the new imagery style URL

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ded1ca116883288bb1b2e841f415e1