### PR TITLE
Refine dataset detail widget layout

### DIFF
--- a/src/lib/data/datasetCatalog.server.ts
+++ b/src/lib/data/datasetCatalog.server.ts
@@ -1,0 +1,307 @@
+import type { DatasetMetadata } from '$lib/types/dataset';
+
+export const datasetCatalog: DatasetMetadata[] = [
+  {
+    id: 'ch.so.energy.solar-potential',
+    title: 'Solar Potential Roofs – Canton Solothurn',
+    summary: 'Detailed assessment of rooftop solar potential for every building in the canton.',
+    description:
+      'The dataset estimates the photovoltaic and solar thermal potential of building roofs using LiDAR derived surfaces and energy simulations. Attributes include irradiation levels, suitable area and recommended technology class.',
+    theme: 'Energy & Environment',
+    provider: 'Amt für Geoinformation Kanton Solothurn',
+    geometryType: 'Polygon',
+    keywords: ['solar', 'energy', 'rooftop', 'photovoltaic', 'thermal'],
+    defaultStyleId: 'potential-classes',
+    defaultVersionId: '2024-q2',
+    mapConfig: {
+      layerType: 'fill',
+      sourceType: 'vector',
+      sourceLayer: 'solar_potential',
+      minzoom: 12,
+      maxzoom: 18
+    },
+    styles: [
+      {
+        id: 'potential-classes',
+        label: 'Solar potential classes',
+        description: 'Choropleth style highlighting roofs by their photovoltaic potential class.',
+        paint: {
+          'fill-color': [
+            'match',
+            ['get', 'pv_class'],
+            'very_high',
+            '#42be65',
+            'high',
+            '#24a148',
+            'medium',
+            '#08bdba',
+            'low',
+            '#007d79',
+            'very_low',
+            '#005d5d',
+            '#3d5467'
+          ],
+          'fill-opacity': 0.75
+        }
+      },
+      {
+        id: 'technology-outline',
+        label: 'Technology outline',
+        description: 'Outlined representation showing the recommended technology per roof segment.',
+        layerTypeOverride: 'line',
+        paint: {
+          'line-color': [
+            'match',
+            ['get', 'tech'],
+            'pv',
+            '#0f62fe',
+            'thermal',
+            '#ff832b',
+            'hybrid',
+            '#8a3ffc',
+            '#525252'
+          ],
+          'line-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            12,
+            0.4,
+            18,
+            2.2
+          ]
+        }
+      }
+    ],
+    versions: [
+      {
+        id: '2024-q2',
+        label: 'Q2 2024 release',
+        url: 'https://data.so.ch/pmtiles/solar-potential/solar_potential_2024_q2.pmtiles',
+        effectiveFrom: '2024-06-15',
+        summary: 'Incorporates 2023 aerial survey updates and refined irradiation modelling.',
+        changes: [
+          'Integrated 7,500 newly constructed roofs from the 2023 cadastral update.',
+          'Improved minimum irradiance threshold for narrow dormers.'
+        ]
+      },
+      {
+        id: '2023-q4',
+        label: 'Q4 2023 release',
+        url: 'https://data.so.ch/pmtiles/solar-potential/solar_potential_2023_q4.pmtiles',
+        effectiveFrom: '2023-11-02',
+        summary: 'Adds building refurbishments and enhanced shading model.',
+        changes: [
+          'Updated shading due to tree growth captured in 2022 LiDAR.',
+          'Recalculated photovoltaic performance for 3,100 roofs.'
+        ]
+      },
+      {
+        id: '2023-q1',
+        label: 'Q1 2023 release',
+        url: 'https://data.so.ch/pmtiles/solar-potential/solar_potential_2023_q1.pmtiles',
+        effectiveFrom: '2023-02-10',
+        summary: 'Baseline publication aligned with the energy strategy 2050.',
+        changes: ['Initial publication of canton-wide rooftop solar suitability.']
+      }
+    ]
+  },
+  {
+    id: 'ch.so.planning.zoning',
+    title: 'Municipal Zoning Plans',
+    summary: 'Current legally binding zoning ordinances harmonised for the entire canton.',
+    description:
+      'Generalised zoning polygons compiled from municipal plans. Each polygon contains land-use category, utilisation rate, building regulations, and legal references. Ideal for planning applications and permit checks.',
+    theme: 'Spatial Planning',
+    provider: 'Amt für Raumplanung Kanton Solothurn',
+    geometryType: 'Polygon',
+    keywords: ['zoning', 'land use', 'planning', 'ordinance'],
+    defaultStyleId: 'landuse-categories',
+    defaultVersionId: '2024-01',
+    mapConfig: {
+      layerType: 'fill',
+      sourceType: 'vector',
+      sourceLayer: 'zoning',
+      minzoom: 10,
+      maxzoom: 18
+    },
+    styles: [
+      {
+        id: 'landuse-categories',
+        label: 'Land-use categories',
+        description: 'Colour by harmonised land-use class with subtle outlines.',
+        paint: {
+          'fill-color': [
+            'match',
+            ['get', 'use'],
+            'residential',
+            '#ff832b',
+            'mixed',
+            '#f1c21b',
+            'commercial',
+            '#8a3ffc',
+            'industrial',
+            '#a56eff',
+            'green',
+            '#42be65',
+            'agricultural',
+            '#007d79',
+            '#3d3d3d'
+          ],
+          'fill-opacity': 0.6
+        },
+        layout: {
+          visibility: 'visible'
+        }
+      },
+      {
+        id: 'outline-only',
+        label: 'Outline only',
+        description: 'Transparent fill with emphasised zoning boundaries.',
+        paint: {
+          'fill-color': '#ffffff',
+          'fill-opacity': 0.05
+        },
+        layout: {
+          visibility: 'visible'
+        }
+      }
+    ],
+    versions: [
+      {
+        id: '2024-01',
+        label: 'January 2024 (harmonised)',
+        url: 'https://data.so.ch/pmtiles/zoning/zoning_2024_01.pmtiles',
+        effectiveFrom: '2024-01-20',
+        summary: 'Includes Bettlach, Grenchen and Oensingen revisions ratified late 2023.',
+        changes: [
+          'Added new mixed-use zone around Oensingen rail station.',
+          'Reclassified Bettlach industrial lots as technology park.'
+        ]
+      },
+      {
+        id: '2023-05',
+        label: 'May 2023 update',
+        url: 'https://data.so.ch/pmtiles/zoning/zoning_2023_05.pmtiles',
+        effectiveFrom: '2023-05-11',
+        summary: 'Incorporates legal changes up to April 2023.',
+        changes: [
+          'Extended residential zone in Derendingen west.',
+          'Updated agricultural reserve boundaries in Leimental.'
+        ]
+      }
+    ]
+  },
+  {
+    id: 'ch.so.transport.cycling-network',
+    title: 'Cycling Network & Quality Levels',
+    summary: 'Hierarchy of cycling infrastructure with safety and comfort ratings.',
+    description:
+      'Authoritative bicycle network dataset including on-road lanes, separated paths, and recommended connections. Attributes include surface type, width, slope, and a quality score derived from field surveys.',
+    theme: 'Mobility',
+    provider: 'Amt für Verkehr und Tiefbau Kanton Solothurn',
+    geometryType: 'Line',
+    keywords: ['cycling', 'mobility', 'transport', 'network'],
+    defaultStyleId: 'quality-levels',
+    defaultVersionId: '2024-routing',
+    mapConfig: {
+      layerType: 'line',
+      sourceType: 'vector',
+      sourceLayer: 'cycling',
+      minzoom: 8,
+      maxzoom: 18
+    },
+    styles: [
+      {
+        id: 'quality-levels',
+        label: 'Quality levels',
+        description: 'Colours reflect the comfort level for everyday cyclists.',
+        paint: {
+          'line-color': [
+            'interpolate',
+            ['linear'],
+            ['get', 'quality'],
+            1,
+            '#fa4d56',
+            3,
+            '#f1c21b',
+            5,
+            '#42be65'
+          ],
+          'line-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            8,
+            1,
+            14,
+            3,
+            18,
+            6
+          ]
+        }
+      },
+      {
+        id: 'surface-type',
+        label: 'Surface type',
+        description: 'Alternative palette to distinguish paved versus unpaved segments.',
+        paint: {
+          'line-color': [
+            'match',
+            ['get', 'surface'],
+            'paved',
+            '#0f62fe',
+            'gravel',
+            '#8d3bff',
+            'dirt',
+            '#d2a106',
+            'unknown',
+            '#8d8d8d',
+            '#161616'
+          ],
+          'line-width': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            8,
+            1,
+            14,
+            3.4,
+            18,
+            5.6
+          ],
+          'line-dasharray': [2, 2]
+        }
+      }
+    ],
+    versions: [
+      {
+        id: '2024-routing',
+        label: 'Routing network 2024',
+        url: 'https://data.so.ch/pmtiles/cycling/cycling_network_2024.pmtiles',
+        effectiveFrom: '2024-08-01',
+        summary: 'Aligns with the 2024 cantonal mobility programme.',
+        changes: [
+          'Quality rating reviewed after the 2023 safety audit.',
+          'Added separated lanes along Kantonsstrasse 12 in Olten.'
+        ]
+      },
+      {
+        id: '2023-routing',
+        label: 'Routing network 2023',
+        url: 'https://data.so.ch/pmtiles/cycling/cycling_network_2023.pmtiles',
+        effectiveFrom: '2023-07-05',
+        summary: 'Baseline routing network published with performance indicators.'
+      },
+      {
+        id: '2022-planning',
+        label: 'Planning network 2022',
+        url: 'https://data.so.ch/pmtiles/cycling/cycling_network_2022.pmtiles',
+        effectiveFrom: '2022-03-18',
+        summary: 'Historic planning version used for long-term projects.',
+        effectiveTo: '2023-07-04'
+      }
+    ]
+  }
+];
+

--- a/src/lib/services/datasetSearch.ts
+++ b/src/lib/services/datasetSearch.ts
@@ -1,0 +1,131 @@
+import type { DatasetMetadata, DatasetSearchResult } from '$lib/types/dataset';
+
+const DATASET_ENDPOINT = '/api/datasets';
+
+const searchableFields: Array<keyof DatasetMetadata | 'keywords'> = [
+  'title',
+  'summary',
+  'description',
+  'theme',
+  'provider',
+  'keywords'
+];
+
+const fieldWeights: Record<string, number> = {
+  title: 4,
+  summary: 3,
+  description: 2,
+  theme: 2,
+  provider: 1,
+  keywords: 3
+};
+
+const normalise = (value: string) => value.trim().toLowerCase();
+
+const collectMatches = (dataset: DatasetMetadata, query: string) => {
+  const matches = new Set<string>();
+  let score = 0;
+
+  for (const field of searchableFields) {
+    const weight = fieldWeights[field] ?? 1;
+    if (field === 'keywords') {
+      if (dataset.keywords.some((keyword) => normalise(keyword).includes(query))) {
+        matches.add('keywords');
+        score += weight;
+      }
+    } else {
+      const value = dataset[field];
+      if (typeof value === 'string' && normalise(value).includes(query)) {
+        matches.add(field);
+        score += weight;
+      }
+    }
+  }
+
+  return { matches: Array.from(matches), score };
+};
+
+let catalogCache: DatasetMetadata[] | null = null;
+let inflightCatalog: Promise<DatasetMetadata[]> | null = null;
+
+const parseCatalogPayload = (payload: unknown): DatasetMetadata[] => {
+  if (Array.isArray(payload)) {
+    return payload as DatasetMetadata[];
+  }
+
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'datasets' in payload &&
+    Array.isArray((payload as { datasets: unknown }).datasets)
+  ) {
+    return (payload as { datasets: DatasetMetadata[] }).datasets;
+  }
+
+  throw new Error('Unexpected dataset catalog payload.');
+};
+
+const fetchCatalog = async (): Promise<DatasetMetadata[]> => {
+  if (catalogCache) {
+    return catalogCache;
+  }
+
+  if (inflightCatalog) {
+    return inflightCatalog;
+  }
+
+  if (typeof fetch === 'undefined') {
+    throw new Error('Fetch API is not available in this environment.');
+  }
+
+  inflightCatalog = fetch(DATASET_ENDPOINT)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load dataset catalog (${response.status})`);
+      }
+      return response.json();
+    })
+    .then((payload) => {
+      const catalog = parseCatalogPayload(payload);
+      catalogCache = catalog;
+      return catalog;
+    })
+    .finally(() => {
+      inflightCatalog = null;
+    });
+
+  return inflightCatalog;
+};
+
+export const clearDatasetCatalogCache = () => {
+  catalogCache = null;
+};
+
+export const searchDatasets = async (query: string): Promise<DatasetSearchResult[]> => {
+  const datasets = await fetchCatalog();
+  const normalisedQuery = normalise(query);
+
+  if (!normalisedQuery) {
+    return [];
+  }
+
+  const results: DatasetSearchResult[] = [];
+
+  for (const dataset of datasets) {
+    const { matches, score } = collectMatches(dataset, normalisedQuery);
+    if (score > 0) {
+      results.push({ dataset, score, matches });
+    }
+  }
+
+  results.sort((a, b) => {
+    if (b.score === a.score) {
+      return a.dataset.title.localeCompare(b.dataset.title);
+    }
+    return b.score - a.score;
+  });
+
+  return results;
+};
+
+export const getDatasetCatalog = async (): Promise<DatasetMetadata[]> => fetchCatalog();

--- a/src/lib/types/dataset.ts
+++ b/src/lib/types/dataset.ts
@@ -1,0 +1,61 @@
+import type { LayerType, PMTilesLayerConfig } from './pmtiles';
+
+export type DatasetGeometryType =
+  | 'Polygon'
+  | 'Line'
+  | 'Point'
+  | 'Raster'
+  | 'Mixed';
+
+export interface DatasetStyleDefinition {
+  id: string;
+  label: string;
+  description: string;
+  layerTypeOverride?: LayerType;
+  paint?: PMTilesLayerConfig['paint'];
+  layout?: PMTilesLayerConfig['layout'];
+}
+
+export interface DatasetVersion {
+  id: string;
+  label: string;
+  url: string;
+  effectiveFrom: string;
+  effectiveTo?: string;
+  summary: string;
+  changes?: string[];
+}
+
+export interface DatasetMetadata {
+  id: string;
+  title: string;
+  summary: string;
+  description: string;
+  theme: string;
+  provider: string;
+  geometryType: DatasetGeometryType;
+  keywords: string[];
+  defaultStyleId: string;
+  defaultVersionId: string;
+  mapConfig: {
+    layerType: LayerType;
+    sourceType?: PMTilesLayerConfig['sourceType'];
+    sourceLayer?: string;
+    minzoom?: number;
+    maxzoom?: number;
+  };
+  styles: DatasetStyleDefinition[];
+  versions: DatasetVersion[];
+}
+
+export interface DatasetSearchResult {
+  dataset: DatasetMetadata;
+  score: number;
+  matches: string[];
+}
+
+export interface SelectedDatasetState {
+  dataset: DatasetMetadata;
+  activeVersionId: string;
+  activeStyleId: string;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,30 @@
 <script lang="ts">
-  import { ComboBox } from 'carbon-components-svelte';
+  import {
+    Button,
+    ComboBox,
+    InlineLoading,
+    Modal,
+    Search,
+    Tag,
+    Tile
+  } from 'carbon-components-svelte';
   import MapView from '$lib/components/MapView.svelte';
   import { basemapOptions, type BasemapId } from '$lib/basemaps';
   import type { PMTilesLayerConfig } from '$lib/types/pmtiles';
+  import type {
+    DatasetSearchResult,
+    DatasetMetadata,
+    SelectedDatasetState,
+    DatasetVersion
+  } from '$lib/types/dataset';
+  import { searchDatasets } from '$lib/services/datasetSearch';
 
-  type MapReadyEvent = CustomEvent<import('maplibre-gl').Map>;
   type BasemapOption = (typeof basemapOptions)[number];
   type BasemapComboBoxItem = BasemapOption & { text: string };
+  type ComboBoxSelectDetail = {
+    selectedId?: string | null;
+    selectedItem?: { id?: string | null } | null;
+  };
 
   if (!basemapOptions.length) {
     throw new Error('No basemap options configured.');
@@ -20,98 +38,1023 @@
   const initialBasemap =
     basemapItems.find((option) => option.id === 'swisstopo') ?? basemapItems[0];
 
-  let mapLoaded = false;
+  const dateFormatter = new Intl.DateTimeFormat('de-CH', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+
   let pmtilesLayers: PMTilesLayerConfig[] = [];
   let selectedId: BasemapId = (initialBasemap?.id ?? basemapItems[0].id) as BasemapId;
   let selectedItem: BasemapComboBoxItem = initialBasemap ?? basemapItems[0];
   let selectedBasemap: BasemapId = selectedItem.id as BasemapId;
 
-  const handleReady = (_event: MapReadyEvent) => {
-    mapLoaded = true;
+  let searchTerm = '';
+  let searching = false;
+  let searchPerformed = false;
+  let searchError: string | null = null;
+  let searchResults: DatasetSearchResult[] = [];
+  let selectedDatasets: SelectedDatasetState[] = [];
+
+  let timelineModalOpen = false;
+  let timelineDatasetId: string | null = null;
+  let expandedResultState: Record<string, boolean> = {};
+  let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+  let searchRequestId = 0;
+
+  const resetSearchState = (cancelOngoing = false) => {
+    if (cancelOngoing) {
+      searchRequestId += 1;
+    }
+    searchResults = [];
+    expandedResultState = {};
+    searchError = null;
+    searchPerformed = false;
   };
 
-  $: selectedItem =
-    basemapItems.find((item) => item.id === selectedId) ?? basemapItems[0];
+  const performSearch = async (term: string) => {
+    const trimmed = term.trim();
+
+    if (!trimmed) {
+      resetSearchState(true);
+      searching = false;
+      return;
+    }
+
+    const requestId = ++searchRequestId;
+    searching = true;
+    searchError = null;
+
+    try {
+      const results = await searchDatasets(trimmed);
+      if (requestId !== searchRequestId) {
+        return;
+      }
+      searchResults = results;
+      expandedResultState = {};
+      searchPerformed = true;
+    } catch (error) {
+      console.error('Failed to search datasets', error);
+      if (requestId === searchRequestId) {
+        searchError = 'The search service is currently unavailable.';
+        searchPerformed = false;
+      }
+    } finally {
+      if (requestId === searchRequestId) {
+        searching = false;
+      }
+    }
+  };
+
+  const queueSearch = (term: string) => {
+    if (searchDebounce) {
+      clearTimeout(searchDebounce);
+      searchDebounce = null;
+    }
+
+    if (!term.trim()) {
+      resetSearchState(true);
+      searching = false;
+      return;
+    }
+
+    searchDebounce = setTimeout(() => {
+      void performSearch(term);
+    }, 250);
+  };
+
+  const handleSearchInput = () => {
+    queueSearch(searchTerm);
+  };
+
+  const handleSearchClear = () => {
+    if (searchDebounce) {
+      clearTimeout(searchDebounce);
+      searchDebounce = null;
+    }
+    searchTerm = '';
+    resetSearchState(true);
+    searching = false;
+  };
+
+  const handleSearchSubmit = async (event: Event) => {
+    event.preventDefault();
+    if (searchDebounce) {
+      clearTimeout(searchDebounce);
+      searchDebounce = null;
+    }
+    await performSearch(searchTerm);
+  };
+
+  const datasetAlreadyAdded = (dataset: DatasetMetadata) =>
+    selectedDatasets.some((entry) => entry.dataset.id === dataset.id);
+
+  const handleStyleSelect = (datasetId: string) => (
+    event: CustomEvent<ComboBoxSelectDetail>
+  ) => {
+    const nextId =
+      event.detail.selectedId ?? event.detail.selectedItem?.id ?? undefined;
+    if (nextId) {
+      changeStyle(datasetId, nextId);
+    }
+  };
+
+  const addDataset = (dataset: DatasetMetadata) => {
+    if (datasetAlreadyAdded(dataset)) {
+      timelineDatasetId = dataset.id;
+      timelineModalOpen = true;
+      return;
+    }
+
+    selectedDatasets = [
+      ...selectedDatasets,
+      {
+        dataset,
+        activeStyleId: dataset.defaultStyleId,
+        activeVersionId: dataset.defaultVersionId
+      }
+    ];
+  };
+
+  const removeDataset = (datasetId: string) => {
+    selectedDatasets = selectedDatasets.filter((entry) => entry.dataset.id !== datasetId);
+    if (timelineDatasetId === datasetId) {
+      timelineDatasetId = null;
+      timelineModalOpen = false;
+    }
+  };
+
+  const changeStyle = (datasetId: string, styleId: string) => {
+    selectedDatasets = selectedDatasets.map((entry) =>
+      entry.dataset.id === datasetId ? { ...entry, activeStyleId: styleId } : entry
+    );
+  };
+
+  const changeVersion = (datasetId: string, versionId: string) => {
+    selectedDatasets = selectedDatasets.map((entry) =>
+      entry.dataset.id === datasetId ? { ...entry, activeVersionId: versionId } : entry
+    );
+  };
+
+  const openTimeline = (datasetId: string) => {
+    timelineDatasetId = datasetId;
+    timelineModalOpen = true;
+  };
+
+  const closeTimeline = () => {
+    timelineModalOpen = false;
+    timelineDatasetId = null;
+  };
+
+  const getDatasetVersion = (dataset: DatasetMetadata, versionId: string) =>
+    dataset.versions.find((version) => version.id === versionId);
+
+  const getLatestVersion = (dataset: DatasetMetadata) => dataset.versions[0] ?? null;
+
+  const toggleResultExpanded = (datasetId: string) => {
+    const nextExpanded = !(expandedResultState[datasetId] ?? false);
+
+    console.log('dataset-result: toggle', {
+      datasetId,
+      expanded: nextExpanded
+    });
+
+    expandedResultState = { ...expandedResultState, [datasetId]: nextExpanded };
+  };
+
+  const formatVersionRange = (version: DatasetVersion) => {
+    if (version.effectiveFrom && version.effectiveTo) {
+      return `${dateFormatter.format(new Date(version.effectiveFrom))} – ${dateFormatter.format(
+        new Date(version.effectiveTo)
+      )}`;
+    }
+
+    if (version.effectiveFrom) {
+      return `Since ${dateFormatter.format(new Date(version.effectiveFrom))}`;
+    }
+
+    return 'Effective date unknown';
+  };
+
+  $: selectedItem = basemapItems.find((item) => item.id === selectedId) ?? basemapItems[0];
   $: selectedBasemap = selectedItem.id as BasemapId;
+
+  $: pmtilesLayers = selectedDatasets.flatMap((entry) => {
+    const style = entry.dataset.styles.find((item) => item.id === entry.activeStyleId);
+    const version = getDatasetVersion(entry.dataset, entry.activeVersionId);
+    if (!style || !version) {
+      return [];
+    }
+
+    return [
+      {
+        id: `${entry.dataset.id}-${style.id}`,
+        url: version.url,
+        layerType: style.layerTypeOverride ?? entry.dataset.mapConfig.layerType,
+        sourceType: entry.dataset.mapConfig.sourceType,
+        sourceLayer: entry.dataset.mapConfig.sourceLayer,
+        paint: style.paint,
+        layout: style.layout,
+        minzoom: entry.dataset.mapConfig.minzoom,
+        maxzoom: entry.dataset.mapConfig.maxzoom
+      }
+    ];
+  });
+
+  $: timelineSelection = timelineDatasetId
+    ? selectedDatasets.find((entry) => entry.dataset.id === timelineDatasetId) ?? null
+    : null;
 </script>
 
-<div class="map-page">
-  <MapView basemap={selectedBasemap} pmtilesLayers={pmtilesLayers} on:ready={handleReady} />
+<div class="page">
+  <main class="map-area">
+    <MapView basemap={selectedBasemap} pmtilesLayers={pmtilesLayers} />
 
-  <div class="basemap-switcher">
-    <ComboBox
-      id="basemap-switcher"
-      class="combo-box"
-      hideLabel
-      titleText="Basemap"
-      placeholder="Choose a basemap"
-      items={basemapItems}
-      itemToString={(item) => (item ? item.text : '')}
-      helperText={selectedItem.description}
-      bind:selectedId={selectedId}
-    />
-  </div>
+    <div class="map-overlays">
+      <div class="map-overlays__bottom">
+        <div class="map-overlays__panel">
+          <ComboBox
+            id="basemap-switcher"
+            class="combo-box"
+            hideLabel
+            titleText="Basemap"
+            direction="top"
+            placeholder="Choose a basemap"
+            items={basemapItems}
+            itemToString={(item) => (item ? item.text : '')}
+            bind:selectedId={selectedId}
+          />
+          <!-- helperText={selectedItem.description} -->
+        </div>
+      </div>
+    </div>
+  </main>
 
-  <p class="map-status" data-testid="map-status">
-    {mapLoaded ? 'Map initialised' : 'Initialising map...'}
-  </p>
+  <aside class="overlay overlay--search" aria-label="Dataset search panel">
+    <section class="panel">
+      <header class="panel__header">
+        <h1>PMTiles data catalogue</h1>
+        <p>Search authoritative vector datasets and add them to the interactive map.</p>
+      </header>
+
+      <form class="search-form" on:submit|preventDefault={handleSearchSubmit}>
+        <Search
+          id="dataset-search"
+          size="lg"
+          labelText="Search datasets"
+          placeholder="Search by title, theme, keyword..."
+          bind:value={searchTerm}
+          on:input={handleSearchInput}
+          on:clear={handleSearchClear}
+        />
+      </form>
+
+      {#if searching}
+        <div class="search-status" role="status">
+          <InlineLoading description="Searching datasets..." />
+        </div>
+      {/if}
+
+      {#if searchError}
+        <p class="search-error" role="alert">{searchError}</p>
+      {/if}
+
+      {#if searchResults.length}
+        <div class="results-list" aria-live="polite">
+          {#each searchResults as result (result.dataset.id)}
+            {@const expanded = !!expandedResultState[result.dataset.id]}
+            <Tile class="result-card">
+              <div class="result-card__collapse" data-dataset-id={result.dataset.id}>
+                <button
+                  type="button"
+                  class="result-card__toggle"
+                  aria-expanded={expanded}
+                  aria-controls={`result-details-${result.dataset.id}`}
+                  on:click={() => toggleResultExpanded(result.dataset.id)}
+                >
+                  <span class="result-card__title" role="heading" aria-level="2">
+                    {result.dataset.title}
+                  </span>
+                  <svg
+                    class="result-card__chevron"
+                    class:result-card__chevron--expanded={expanded}
+                    aria-hidden="true"
+                    focusable="false"
+                    viewBox="0 0 16 16"
+                  >
+                    <path d="M13.41 5.59 12 4.17 8 8.17l-4-4-1.41 1.42L8 11l5.41-5.41Z" />
+                  </svg>
+                </button>
+
+                {#if expanded}
+                  {@const latestVersion = getLatestVersion(result.dataset)}
+                  <div
+                    class="result-card__details"
+                    id={`result-details-${result.dataset.id}`}
+                  >
+                    <div class="result-card__tags">
+                      <Tag type="cool-gray" size="sm">{result.dataset.theme}</Tag>
+                      <Tag type="teal" size="sm">{result.dataset.geometryType}</Tag>
+                    </div>
+                    <div class="result-card__meta">
+                      <div class="result-card__provider">{result.dataset.provider}</div>
+                    </div>
+                    <p class="result-card__description">{result.dataset.description}</p>
+                    <div class="result-card__info-grid">
+                      <dl class="result-card__definition-list">
+                        <div>
+                          <dt>Default style</dt>
+                          <dd>
+                            {result.dataset.styles.find((style) => style.id === result.dataset.defaultStyleId)?.label}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt>Default version</dt>
+                          <dd>
+                            {result.dataset.versions.find((version) => version.id === result.dataset.defaultVersionId)?.label}
+                          </dd>
+                        </div>
+                      </dl>
+                      <div class="result-card__keywords">
+                        <h3>Keywords</h3>
+                        <div class="result-card__keyword-tags">
+                          {#each result.dataset.keywords as keyword}
+                            <Tag type="purple" size="sm">{keyword}</Tag>
+                          {/each}
+                        </div>
+                        {#if result.matches.length}
+                          <div class="result-card__matches" aria-label="Search matches">
+                            {#each result.matches as match}
+                              <Tag type="blue" size="sm">{match}</Tag>
+                            {/each}
+                          </div>
+                        {/if}
+                      </div>
+                    </div>
+                    <div class="result-card__styles">
+                      <h3>Available styles</h3>
+                      <ul>
+                        {#each result.dataset.styles as style}
+                          <li>
+                            <div class="result-card__style-header">
+                              <span class="result-card__style-title">{style.label}</span>
+                              {#if style.id === result.dataset.defaultStyleId}
+                                <Tag type="green" size="sm">Default</Tag>
+                              {/if}
+                            </div>
+                            <p>{style.description}</p>
+                          </li>
+                        {/each}
+                      </ul>
+                    </div>
+                    <div class="result-card__latest-version">
+                      <h3>Latest version</h3>
+                      {#if latestVersion}
+                        <div class="result-card__latest-version-meta">
+                          <span>{latestVersion.label}</span>
+                          <span>{formatVersionRange(latestVersion)}</span>
+                        </div>
+                        <p>{latestVersion.summary}</p>
+                      {:else}
+                        <p>No version history available.</p>
+                      {/if}
+                    </div>
+                    <div class="result-card__actions">
+                      <Button
+                        kind="primary"
+                        size="small"
+                        disabled={datasetAlreadyAdded(result.dataset)}
+                        on:click={() => addDataset(result.dataset)}
+                      >
+                        {datasetAlreadyAdded(result.dataset) ? 'Already on map' : 'Add to map'}
+                      </Button>
+                      <Button
+                        kind="ghost"
+                        size="small"
+                        on:click={() => openTimeline(result.dataset.id)}
+                      >
+                        View versions
+                      </Button>
+                    </div>
+                  </div>
+                {/if}
+              </div>
+            </Tile>
+          {/each}
+        </div>
+      {:else if searchPerformed && !searching}
+        <p class="search-empty">No datasets matched your search. Try another keyword.</p>
+      {/if}
+    </section>
+  </aside>
+
+  <aside class="overlay overlay--toc" aria-label="Table of contents">
+    <section class="panel">
+      <header class="panel__header">
+        <h2>Table of contents</h2>
+        <p>Manage the datasets currently shown on the map.</p>
+      </header>
+
+      {#if selectedDatasets.length === 0}
+        <p class="empty-state">No datasets added yet. Use the search to add layers.</p>
+      {:else}
+        <div class="toc-list">
+          {#each selectedDatasets as entry (entry.dataset.id)}
+            {#key `${entry.dataset.id}-${entry.activeStyleId}-${entry.activeVersionId}`}
+              <Tile class="toc-card">
+                <div class="toc-card__header">
+                  <div>
+                    <h3>{entry.dataset.title}</h3>
+                    <p>{entry.dataset.summary}</p>
+                  </div>
+                  <Button
+                    kind="ghost"
+                    size="small"
+                    iconDescription="Remove dataset"
+                    on:click={() => removeDataset(entry.dataset.id)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+                <div class="toc-card__tags">
+                  <Tag type="cool-gray" size="sm">{entry.dataset.theme}</Tag>
+                  <Tag type="purple" size="sm">{entry.dataset.geometryType}</Tag>
+                </div>
+                <div class="toc-card__controls">
+                  <ComboBox
+                    id={`style-${entry.dataset.id}`}
+                    class="style-combobox"
+                    titleText="Style"
+                    hideLabel
+                    helperText={
+                      entry.dataset.styles.find((style) => style.id === entry.activeStyleId)?.description
+                    }
+                    items={entry.dataset.styles.map((style) => ({
+                      id: style.id,
+                      text: style.label
+                    }))}
+                    selectedId={entry.activeStyleId}
+                    itemToString={(item) => (item ? item.text : '')}
+                    on:select={handleStyleSelect(entry.dataset.id)}
+                  />
+                  <Button kind="tertiary" size="small" on:click={() => openTimeline(entry.dataset.id)}>
+                    Version timeline
+                  </Button>
+                </div>
+                {@const activeVersion = getDatasetVersion(entry.dataset, entry.activeVersionId)}
+                {#if activeVersion}
+                  <div class="toc-card__version">
+                    <span class="toc-card__version-label">{activeVersion.label}</span>
+                    <span class="toc-card__version-range">{formatVersionRange(activeVersion)}</span>
+                  </div>
+                {/if}
+              </Tile>
+            {/key}
+          {/each}
+        </div>
+      {/if}
+    </section>
+  </aside>
 </div>
 
+<Modal
+  size="lg"
+  open={timelineModalOpen}
+  modalHeading={timelineSelection ? `Version history – ${timelineSelection.dataset.title}` : 'Version history'}
+  modalLabel="Dataset versions"
+  on:close={closeTimeline}
+  passiveModal
+  hasScrollingContent
+>
+  {#if timelineSelection}
+    <div class="timeline-list">
+      {#each timelineSelection.dataset.versions as version}
+        <button
+          type="button"
+          class:timeline-list__item--active={timelineSelection.activeVersionId === version.id}
+          class="timeline-list__item"
+          on:click={() => {
+            changeVersion(timelineSelection.dataset.id, version.id);
+            closeTimeline();
+          }}
+        >
+          <div class="timeline-list__item-header">
+            <h3>{version.label}</h3>
+            {#if timelineSelection.activeVersionId === version.id}
+              <Tag type="green" size="sm">Active</Tag>
+            {/if}
+          </div>
+          <p class="timeline-list__range">{formatVersionRange(version)}</p>
+          <p class="timeline-list__summary">{version.summary}</p>
+          {#if version.changes?.length}
+            <ul class="timeline-list__changes">
+              {#each version.changes as change}
+                <li>{change}</li>
+              {/each}
+            </ul>
+          {/if}
+        </button>
+      {/each}
+    </div>
+  {:else}
+    <p>No dataset selected.</p>
+  {/if}
+</Modal>
+
 <style>
-  .map-page {
-    position: fixed;
-    inset: 0;
-    display: flex;
-    flex-direction: column;
+  .page {
+    --page-gap: clamp(0.5rem, 1.5vw, 1.25rem);
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    background: var(--cds-ui-background, #f4f4f4);
+    overflow: hidden;
+    color: var(--cds-text-primary, #161616);
   }
 
-  .map-page :global(.map),
-  .map-page :global(.map-error) {
-    flex: 1 1 auto;
+  :global(body) {
+    margin: 0;
+    background: var(--cds-ui-background, #f4f4f4);
+    font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  .map-area {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+
+  .map-area :global(.map) {
+    width: 100%;
     height: 100%;
   }
 
-  .basemap-switcher {
+  .overlay {
     position: absolute;
-    top: clamp(1rem, 4vw, 2.5rem);
-    left: 50%;
-    transform: translateX(-50%);
-    width: min(90vw, 22rem);
-    padding: 0.5rem 0.75rem 0.75rem;
-    background: var(--cds-layer, #fff);
-    border: 1px solid var(--cds-border-subtle, #e0e0e0);
-    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: clamp(1.25rem, 2.5vw, 1.75rem);
+    width: min(26rem, calc(100vw - 2 * var(--page-gap)));
+    max-height: calc(100vh - 2 * var(--page-gap));
+    background: var(--cds-layer, rgba(255, 255, 255, 0.94));
+    border-radius: 0.75rem;
+    box-shadow: 0 1.5rem 3.5rem rgba(22, 22, 22, 0.18);
+    backdrop-filter: blur(10px);
+    overflow-y: auto;
+    z-index: 2;
+    transform: none;
   }
 
-  .basemap-switcher :global(.combo-box) {
+  .overlay--search {
+    top: var(--page-gap);
+    left: var(--page-gap);
+  }
+
+  .overlay--toc {
+    top: var(--page-gap);
+    right: var(--page-gap);
+  }
+
+  @media (max-width: 1200px) {
+    .overlay--toc {
+      top: auto;
+      bottom: var(--page-gap);
+    }
+  }
+
+  @media (max-width: 960px) {
+    .overlay {
+      left: 50%;
+      right: auto;
+      transform: translateX(-50%);
+      width: min(32rem, calc(100vw - 2 * var(--page-gap)));
+    }
+
+    .overlay--search {
+      top: var(--page-gap);
+    }
+
+    .overlay--toc {
+      top: auto;
+      bottom: var(--page-gap);
+    }
+  }
+
+  @media (max-width: 640px) {
+    .overlay {
+      width: calc(100vw - 2 * var(--page-gap));
+      max-height: calc(100vh - 2 * var(--page-gap));
+    }
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .panel__header h1,
+  .panel__header h2 {
+    margin: 0 0 0.25rem;
+    font-size: 1.25rem;
+    line-height: 1.4;
+  }
+
+  .panel__header p {
+    margin: 0;
+    color: var(--cds-text-secondary, #525252);
+  }
+
+  .search-form {
+    display: block;
+  }
+
+  .search-form :global(.cds--search) {
     width: 100%;
   }
 
-  .map-status {
-    position: absolute;
-    bottom: clamp(1rem, 4vw, 2.5rem);
-    left: 50%;
-    transform: translateX(-50%);
+  .search-status {
+    display: flex;
+    justify-content: center;
+    padding: 0.5rem 0;
+  }
+
+  .search-error {
     margin: 0;
-    padding: 0.5rem 0.75rem;
-    border-radius: 999px;
-    background: rgba(22, 22, 22, 0.7);
-    color: #fff;
-    font-size: 0.875rem;
-    letter-spacing: 0.01em;
-    box-shadow: 0 0.5rem 1.5rem rgba(22, 22, 22, 0.25);
+    color: var(--cds-text-error, #da1e28);
+    font-weight: 600;
+  }
+
+  .results-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  :global(.result-card) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .result-card__collapse {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin: 0;
+  }
+
+  .result-card__toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+    border: none;
+    background: transparent;
+    list-style: none;
+  }
+
+  .result-card__toggle:focus-visible {
+    outline: 2px solid var(--cds-focus, #0f62fe);
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+  }
+
+  .result-card__toggle::marker,
+  .result-card__toggle::-webkit-details-marker {
+    display: none;
+  }
+
+  .result-card__title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    line-height: 1.4;
+  }
+
+  .result-card__chevron {
+    width: 0.75rem;
+    height: 0.75rem;
+    flex-shrink: 0;
+    display: block;
+    fill: currentColor;
+    transition: transform 0.2s ease;
+  }
+
+  .result-card__chevron--expanded {
+    transform: rotate(180deg);
+  }
+
+  .result-card__details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .result-card__tags {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.35rem;
+  }
+
+  .result-card__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.9rem;
+    color: var(--cds-text-helper, #6f6f6f);
+  }
+
+  .result-card__provider {
+    font-weight: 600;
+    color: var(--cds-text-primary, #161616);
+  }
+
+  .result-card__description {
+    margin: 0;
+    color: var(--cds-text-secondary, #525252);
+  }
+
+  .result-card__info-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .result-card__definition-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+  }
+
+  .result-card__definition-list div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .result-card__definition-list dt {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--cds-text-helper, #6f6f6f);
+  }
+
+  .result-card__definition-list dd {
+    margin: 0;
+    font-weight: 600;
+    color: var(--cds-text-primary, #161616);
+  }
+
+  .result-card__keywords {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .result-card__keywords h3,
+  .result-card__styles h3,
+  .result-card__latest-version h3 {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+
+  .result-card__keyword-tags,
+  .result-card__matches {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .result-card__styles ul {
+    margin: 0;
+    padding-left: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    list-style: none;
+  }
+
+  .result-card__styles li {
+    list-style: none;
+    border-left: 2px solid var(--cds-border-strong-01, #8d8d8d);
+    padding-left: 0.75rem;
+  }
+
+  .result-card__style-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+  }
+
+  .result-card__style-title {
+    color: var(--cds-text-primary, #161616);
+  }
+
+  .result-card__styles p {
+    margin: 0.25rem 0 0;
+    color: var(--cds-text-secondary, #525252);
+  }
+
+  .result-card__latest-version {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .result-card__latest-version-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: var(--cds-text-primary, #161616);
+  }
+
+  .result-card__latest-version p {
+    margin: 0;
+    color: var(--cds-text-secondary, #525252);
+  }
+
+  .result-card__actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .search-empty,
+  .empty-state {
+    margin: 0;
+    color: var(--cds-text-secondary, #525252);
+  }
+
+  .toc-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  :global(.toc-card) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .toc-card__header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .toc-card__header h3 {
+    margin: 0 0 0.3rem;
+    font-size: 1.05rem;
+  }
+
+  .toc-card__header p {
+    margin: 0;
+    color: var(--cds-text-secondary, #525252);
+  }
+
+  .toc-card__tags {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .toc-card__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .toc-card__controls :global(.combo-box) {
+    width: min(16rem, 100%);
+  }
+
+  :global(.style-combobox .cds--list-box__menu) {
+    max-height: 14rem;
+  }
+
+  .toc-card__version {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    font-size: 0.85rem;
+    color: var(--cds-text-helper, #6f6f6f);
+  }
+
+  .toc-card__version-label {
+    font-weight: 600;
+    color: var(--cds-text-primary, #161616);
+  }
+
+  .map-overlays {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: var(--page-gap);
+  }
+
+  .map-overlays__bottom {
+    display: flex;
+    justify-content: center;
+  }
+
+  .map-overlays__panel {
+    pointer-events: auto;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 0.5rem 0.75rem 0.75rem;
+    border-radius: 0.25rem;
+    box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.15);
     backdrop-filter: blur(6px);
   }
 
-  @media (max-width: 480px) {
-    .basemap-switcher {
-      padding: 0.5rem 0.5rem 0.65rem;
-      backdrop-filter: blur(4px);
+  .map-overlays__panel :global(.combo-box) {
+    width: min(18rem, 60vw);
+  }
+
+  .timeline-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .timeline-list__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    text-align: left;
+    padding: 0.75rem;
+    border: 1px solid var(--cds-border-subtle, #e0e0e0);
+    border-radius: 0.25rem;
+    background: var(--cds-layer, #ffffff);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    cursor: pointer;
+  }
+
+  .timeline-list__item:hover,
+  .timeline-list__item:focus-visible {
+    border-color: var(--cds-interactive, #0f62fe);
+    box-shadow: 0 0 0 2px rgba(15, 98, 254, 0.15);
+    outline: none;
+  }
+
+  .timeline-list__item--active {
+    border-color: var(--cds-support-success, #24a148);
+    box-shadow: 0 0 0 2px rgba(36, 161, 72, 0.2);
+  }
+
+  .timeline-list__item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .timeline-list__item-header h3 {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .timeline-list__range,
+  .timeline-list__summary {
+    margin: 0;
+    color: var(--cds-text-secondary, #525252);
+    font-size: 0.9rem;
+  }
+
+  .timeline-list__changes {
+    margin: 0;
+    padding-left: 1.1rem;
+    color: var(--cds-text-secondary, #525252);
+    font-size: 0.85rem;
+  }
+
+  @media (max-width: 768px) {
+    .map-overlays {
+      padding: clamp(0.75rem, 4vw, 1rem);
     }
 
-    .map-status {
-      font-size: 0.75rem;
-      padding: 0.4rem 0.6rem;
+    .map-overlays__panel :global(.combo-box) {
+      width: min(16rem, 70vw);
+    }
+
+  }
+
+  @media (max-width: 480px) {
+    .map-overlays__panel :global(.combo-box) {
+      width: min(14rem, 80vw);
     }
   }
 </style>

--- a/src/routes/api/datasets/+server.ts
+++ b/src/routes/api/datasets/+server.ts
@@ -1,0 +1,4 @@
+import { json } from '@sveltejs/kit';
+import { datasetCatalog } from '$lib/data/datasetCatalog.server';
+
+export const GET = () => json(datasetCatalog);


### PR DESCRIPTION
## Summary
- remove the dataset summary line so only the description is shown and inherits the previous summary styling
- drop the source layer and zoom range entries from the dataset metadata list in the search results

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dfd8aaa4c88328b1ee67edfe0763c5