### PR TITLE
Allow adding datasets multiple times

### DIFF
--- a/src/lib/types/dataset.ts
+++ b/src/lib/types/dataset.ts
@@ -55,6 +55,7 @@ export interface DatasetSearchResult {
 }
 
 export interface SelectedDatasetState {
+  instanceId: string;
   dataset: DatasetMetadata;
   activeVersionId: string;
   activeStyleId: string;


### PR DESCRIPTION
## Summary
- allow multiple selections of the same dataset by assigning per-instance identifiers and updating map layer syncing
- keep the add buttons active so datasets can be added again for different versions, and refresh UI messaging accordingly
- adjust table-of-contents and timeline interactions to target specific dataset instances when changing styles or versions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e29e2e70bc8328bf42062eb27cad27