### PR TITLE
Adjust TOC card control layout

### DIFF
--- a/src/lib/types/dataset.ts
+++ b/src/lib/types/dataset.ts
@@ -59,4 +59,5 @@ export interface SelectedDatasetState {
   dataset: DatasetMetadata;
   activeVersionId: string;
   activeStyleId: string;
+  visible: boolean;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -700,6 +700,7 @@
     box-shadow: 0 1.5rem 3.5rem rgba(22, 22, 22, 0.18);
     backdrop-filter: blur(10px);
     overflow-y: auto;
+    overflow-x: hidden;
     z-index: 2;
     transform: none;
   }
@@ -1079,6 +1080,7 @@
     cursor: pointer;
     color: inherit;
     width: 100%;
+    min-width: 0;
   }
 
   .toc-card__toggle:focus-visible {
@@ -1090,6 +1092,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.15rem;
+    min-width: 0;
   }
 
   .toc-card__title {
@@ -1102,6 +1105,8 @@
   .toc-card__chevron {
     width: 0.75rem;
     height: 0.75rem;
+    flex-shrink: 0;
+    display: block;
     fill: currentColor;
     transition: transform 0.2s ease;
   }


### PR DESCRIPTION
## Summary
- prevent the TOC visibility checkbox from stretching across the card header
- align the TOC chevron size with the search results cards for consistency

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e2a8f21b808328beacf88c60f55001