### PR TITLE
Reduce spacing around dataset cards

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -793,13 +793,14 @@
   .results-list {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0;
   }
 
   :global(.result-card) {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
+    margin: 0;
   }
 
   .result-card__collapse {
@@ -1035,13 +1036,14 @@
   .toc-list {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0;
   }
 
   :global(.toc-card) {
     display: flex;
     flex-direction: column;
     gap: 0;
+    margin: 0;
   }
 
   .toc-card__collapse {


### PR DESCRIPTION
## Summary
- remove the extra gap between dataset result entries and TOC cards
- reset tile margins so dataset headers sit closer together

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e37b34fa2c8328a6c848d80b399e22