### PR TITLE
Add dataset-specific PMTiles layers with random styling

### DIFF
--- a/src/lib/services/__tests__/pmtilesLayers.spec.ts
+++ b/src/lib/services/__tests__/pmtilesLayers.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import type { DatasetMetadata, SelectedDatasetState } from '$lib/types/dataset';
+import type { LayerType } from '$lib/types/pmtiles';
+import {
+  applyColorToPaint,
+  createColorFromSeed,
+  createLayerConfigForDataset
+} from '../pmtilesLayers';
+
+const createDataset = (layerType: LayerType): DatasetMetadata => ({
+  id: 'dataset-1',
+  title: 'Test dataset',
+  summary: 'Summary',
+  description: 'Description',
+  theme: 'Theme',
+  provider: 'Provider',
+  geometryType: 'Polygon',
+  keywords: [],
+  defaultStyleId: 'default',
+  defaultVersionId: 'v1',
+  mapConfig: {
+    layerType,
+    sourceLayer: 'layer',
+    sourceType: 'vector',
+    minzoom: 0,
+    maxzoom: 14
+  },
+  styles: [
+    {
+      id: 'default',
+      label: 'Default',
+      description: 'Default style',
+      paint: {
+        'line-width': 4
+      },
+      layout: {
+        visibility: 'visible'
+      }
+    }
+  ],
+  versions: [
+    {
+      id: 'v1',
+      label: 'v1',
+      url: 'https://example.com/data.pmtiles',
+      effectiveFrom: '2024-01-01',
+      summary: 'Initial'
+    }
+  ]
+});
+
+const createSelectedDataset = (layerType: LayerType): SelectedDatasetState => ({
+  instanceId: 'instance-123',
+  dataset: createDataset(layerType),
+  activeStyleId: 'default',
+  activeVersionId: 'v1',
+  visible: true
+});
+
+describe('pmtilesLayers service', () => {
+  it('generates deterministic colors from a seed', () => {
+    const first = createColorFromSeed('abc');
+    const second = createColorFromSeed('abc');
+    const third = createColorFromSeed('def');
+
+    expect(first).toMatch(/^#[0-9a-fA-F]{6}$/);
+    expect(second).toBe(first);
+    expect(third).not.toBe(first);
+  });
+
+  it('applies random color overrides and preserves existing paint values', () => {
+    const paint = applyColorToPaint({ 'line-width': 4 }, 'line', '#123456');
+    expect(paint['line-color']).toBe('#123456');
+    expect(paint['line-width']).toBe(4);
+    expect(paint['line-opacity']).toBeCloseTo(0.9);
+  });
+
+  it('creates a layer configuration with the dataset version url', () => {
+    const entry = createSelectedDataset('line');
+    const config = createLayerConfigForDataset(entry);
+    const color = createColorFromSeed(entry.instanceId);
+
+    expect(config).not.toBeNull();
+    expect(config?.id).toBe(entry.instanceId);
+    expect(config?.url).toBe('https://example.com/data.pmtiles');
+    expect(config?.layerType).toBe('line');
+    expect(config?.paint?.['line-color']).toBe(color);
+    expect(config?.layout).toEqual({ visibility: 'visible' });
+  });
+
+  it('returns null when the dataset has no matching version', () => {
+    const entry = createSelectedDataset('fill');
+    entry.activeVersionId = 'missing';
+
+    const config = createLayerConfigForDataset(entry);
+    expect(config).toBeNull();
+  });
+});

--- a/src/lib/services/pmtilesLayers.ts
+++ b/src/lib/services/pmtilesLayers.ts
@@ -1,0 +1,138 @@
+import type { DatasetStyleDefinition, SelectedDatasetState } from '$lib/types/dataset';
+import type { LayerType, PMTilesLayerConfig } from '$lib/types/pmtiles';
+
+const COLOR_PROPERTIES: Partial<Record<LayerType, string[]>> = {
+  background: ['background-color'],
+  fill: ['fill-color'],
+  line: ['line-color'],
+  circle: ['circle-color'],
+  symbol: ['text-color', 'icon-color'],
+  'fill-extrusion': ['fill-extrusion-color']
+};
+
+const DEFAULTS: Partial<Record<LayerType, Record<string, unknown>>> = {
+  fill: {
+    'fill-opacity': 0.65
+  },
+  line: {
+    'line-width': 2,
+    'line-opacity': 0.9
+  },
+  circle: {
+    'circle-radius': 5,
+    'circle-opacity': 0.85
+  },
+  symbol: {
+    'text-halo-width': 1.2,
+    'text-halo-color': '#ffffff',
+    'text-opacity': 0.95
+  },
+  'fill-extrusion': {
+    'fill-extrusion-opacity': 0.75
+  }
+};
+
+const hashSeed = (seed: string) => {
+  let hash = 0;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = (hash * 31 + seed.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+};
+
+const hslToHex = (h: number, s: number, l: number) => {
+  if (s === 0) {
+    const gray = Math.round(l * 255)
+      .toString(16)
+      .padStart(2, '0');
+    return `#${gray}${gray}${gray}`;
+  }
+
+  const hueToChannel = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+
+  const r = Math.round(hueToChannel(p, q, h + 1 / 3) * 255)
+    .toString(16)
+    .padStart(2, '0');
+  const g = Math.round(hueToChannel(p, q, h) * 255)
+    .toString(16)
+    .padStart(2, '0');
+  const b = Math.round(hueToChannel(p, q, h - 1 / 3) * 255)
+    .toString(16)
+    .padStart(2, '0');
+
+  return `#${r}${g}${b}`;
+};
+
+export const createColorFromSeed = (seed: string) => {
+  const hash = hashSeed(seed);
+  const hue = (hash % 360) / 360;
+  const saturation = 0.65;
+  const lightness = 0.55;
+  return hslToHex(hue, saturation, lightness);
+};
+
+export const applyColorToPaint = (
+  basePaint: DatasetStyleDefinition['paint'],
+  layerType: LayerType,
+  color: string
+) => {
+  const paint: Record<string, unknown> = { ...(basePaint ?? {}) };
+  const properties = COLOR_PROPERTIES[layerType];
+  if (properties) {
+    for (const property of properties) {
+      paint[property] = color;
+    }
+  }
+
+  const defaults = DEFAULTS[layerType];
+  if (defaults) {
+    for (const [property, value] of Object.entries(defaults)) {
+      if (paint[property] === undefined) {
+        paint[property] = value;
+      }
+    }
+  }
+
+  return paint;
+};
+
+export const cloneLayout = (layout: DatasetStyleDefinition['layout']) =>
+  layout ? { ...layout } : undefined;
+
+export const createLayerConfigForDataset = (
+  entry: SelectedDatasetState
+): PMTilesLayerConfig | null => {
+  const style = entry.dataset.styles.find((item) => item.id === entry.activeStyleId);
+  const version = entry.dataset.versions.find((item) => item.id === entry.activeVersionId);
+
+  if (!version) {
+    return null;
+  }
+
+  const layerType = style?.layerTypeOverride ?? entry.dataset.mapConfig.layerType;
+  const color = createColorFromSeed(entry.instanceId);
+  const paint = applyColorToPaint(style?.paint, layerType, color);
+  const layout = cloneLayout(style?.layout);
+
+  return {
+    id: entry.instanceId,
+    url: version.url,
+    layerType,
+    sourceType: entry.dataset.mapConfig.sourceType,
+    sourceLayer: entry.dataset.mapConfig.sourceLayer,
+    paint,
+    layout,
+    minzoom: entry.dataset.mapConfig.minzoom,
+    maxzoom: entry.dataset.mapConfig.maxzoom
+  } satisfies PMTilesLayerConfig;
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,6 +18,7 @@
     SelectedDatasetState,
     DatasetVersion
   } from '$lib/types/dataset';
+  import { createLayerConfigForDataset } from '$lib/services/pmtilesLayers';
   import { searchDatasets } from '$lib/services/datasetSearch';
   import AddAlt from 'carbon-icons-svelte/lib/AddAlt.svelte';
   import TrashCan from 'carbon-icons-svelte/lib/TrashCan.svelte';
@@ -277,25 +278,8 @@
       return [];
     }
 
-    const style = entry.dataset.styles.find((item) => item.id === entry.activeStyleId);
-    const version = getDatasetVersion(entry.dataset, entry.activeVersionId);
-    if (!style || !version) {
-      return [];
-    }
-
-    return [
-      {
-        id: entry.instanceId,
-        url: version.url,
-        layerType: style.layerTypeOverride ?? entry.dataset.mapConfig.layerType,
-        sourceType: entry.dataset.mapConfig.sourceType,
-        sourceLayer: entry.dataset.mapConfig.sourceLayer,
-        paint: style.paint,
-        layout: style.layout,
-        minzoom: entry.dataset.mapConfig.minzoom,
-        maxzoom: entry.dataset.mapConfig.maxzoom
-      }
-    ];
+    const config = createLayerConfigForDataset(entry);
+    return config ? [config] : [];
   });
 
   $: timelineSelection = timelineDatasetId

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -12,9 +12,47 @@ if (typeof window !== 'undefined' && !('ResizeObserver' in window)) {
 
 vi.mock('maplibre-gl', () => {
   class MockMap {
+    static instances: MockMap[] = [];
+
     private handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+    private sources = new Map<string, unknown>();
+    private layers = new Map<string, { id: string }>();
+
+    addSource = vi.fn((id: string, source: unknown) => {
+      this.sources.set(id, source);
+    });
+
+    removeSource = vi.fn((id: string) => {
+      this.sources.delete(id);
+    });
+
+    getSource = vi.fn((id: string) => this.sources.get(id));
+
+    addLayer = vi.fn((layer: { id: string }) => {
+      this.layers.set(layer.id, layer);
+    });
+
+    removeLayer = vi.fn((id: string) => {
+      this.layers.delete(id);
+    });
+
+    getLayer = vi.fn((id: string) => this.layers.get(id));
+
+    setPaintProperty = vi.fn();
+    setLayoutProperty = vi.fn();
+
+    remove = vi.fn();
+
+    setStyle = vi.fn((_style: unknown) => {
+      this.sources.clear();
+      this.layers.clear();
+      this.emit('load');
+    });
+
+    isStyleLoaded = vi.fn(() => true);
 
     constructor(_options: unknown) {
+      MockMap.instances.push(this);
       setTimeout(() => this.emit('load'), 0);
     }
 
@@ -35,26 +73,6 @@ vi.mock('maplibre-gl', () => {
       handler();
       return this;
     }
-
-    remove() {}
-    setStyle(_style: unknown) {
-      this.emit('load');
-    }
-    isStyleLoaded() {
-      return true;
-    }
-    getLayer(_id: string) {
-      return undefined;
-    }
-    addLayer(_layer: unknown) {}
-    removeLayer(_id: string) {}
-    getSource(_id: string) {
-      return undefined;
-    }
-    addSource(_id: string, _source: unknown) {}
-    removeSource(_id: string) {}
-    setPaintProperty(_id: string, _name: string, _value: unknown) {}
-    setLayoutProperty(_id: string, _name: string, _value: unknown) {}
   }
 
   const addProtocol = vi.fn();


### PR DESCRIPTION
## Summary
- derive PMTiles layer configurations from selected datasets so each uses its version URL and a seeded random colour style
- expose maplibre mock internals for inspection in tests while keeping map teardown predictable
- cover the new layer builder utilities with unit tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e38725a20483289ea292c5d6c81086